### PR TITLE
refactor: convert devcontainer from alpine to ubuntu

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
 # Ref: https://github.com/devcontainers/ci/issues/191
-FROM mcr.microsoft.com/devcontainers/base:alpine
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04

--- a/.devcontainer/features/devcontainer-feature.json
+++ b/.devcontainer/features/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "name": "Flux Cluster Template (Tools)",
   "id": "cluster-template",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Install Tools"
 }

--- a/.devcontainer/features/install.sh
+++ b/.devcontainer/features/install.sh
@@ -2,18 +2,18 @@
 set -e
 set -o noglob
 
-apk add --no-cache \
-    age bash bind-tools ca-certificates curl direnv gettext python3 \
-    py3-pip moreutils jq git iputils openssh-client openssl \
+# Update package list and install packages
+apt-get update
+apt-get install -y --no-install-recommends \
+    age bash bind9-dnsutils ca-certificates curl direnv gettext python3 \
+    python3-pip moreutils jq git iputils-ping openssh-client openssl \
     starship fzf fish yq helm
 
-apk add --no-cache \
-    --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-        kubectl sops
+# Install kubectl and sops
+apt-get install -y --no-install-recommends kubectl sops
 
-apk add --no-cache \
-    --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing \
-        lsd
+# Install lsd
+apt-get install -y --no-install-recommends lsd
 
 for app in \
     "budimanjojo/talhelper!!?as=talhelper&type=script" \


### PR DESCRIPTION
This pull request includes several important changes to the `.devcontainer` configuration, primarily focused on switching the base image from Alpine to Ubuntu and updating the installation scripts accordingly.

### Changes to base image and installation scripts:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L2-R2): Changed the base image from `alpine` to `ubuntu-22.04` to align with the new requirements.
* [`.devcontainer/features/devcontainer-feature.json`](diffhunk://#diff-7586a3f37748a94d493c0e72193de03d9b4505b966445bd7bea903b32779ee7fL4-R4): Updated the version of the `cluster-template` feature from `1.0.0` to `2.0.0`.
* [`.devcontainer/features/install.sh`](diffhunk://#diff-d8dc14d6c3a5e731e1f7c095cf54a8d6c7e6aae66e8bcf35805d694f2b9e92b4L5-R16): Updated the package installation commands from `apk` (used for Alpine) to `apt-get` (used for Ubuntu), including necessary adjustments to package names and installation options.