### PR TITLE
Update devcontainer image and terminal profiles; install k9s

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Homelab",
-    "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.10",
     "runArgs": ["--device=/dev/net/tun"],
     "features": {
       "ghcr.io/devcontainers/features/docker-in-docker:2": {},
@@ -12,7 +12,15 @@
     "customizations": {
       "vscode": {
         "settings": {
-          "terminal.integrated.shell.linux": "/bin/bash",
+          "terminal.integrated.profiles.linux": {
+            "bash": {
+              "path": "/bin/bash"
+            },
+            "zsh": {
+              "path": "zsh"
+            }
+          },
+          "terminal.integrated.defaultProfile.linux": "bash",
           "extensions": [
             "ms-azuretools.vscode-docker",
             "ms-vscode-remote.remote-containers",
@@ -34,4 +42,4 @@
         }
       }
     }
-  }
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -9,4 +9,7 @@ sudo apt update
 sudo apt install -y mise
 
 # add a line to the bash profile of the visual studio code user
-echo "eval "$(mise activate bash --shims)"" >> /home/vscode/.bash_profile
+echo 'eval "$(mise activate bash)"' >> /home/vscode/.bashrc
+
+# install k9s
+wget https://github.com/derailed/k9s/releases/download/v0.32.7/k9s_linux_amd64.deb && apt install ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb


### PR DESCRIPTION
Change the devcontainer image to a Python base and enhance terminal profile settings to support both Bash and Zsh. Additionally, install k9s for Kubernetes management.