### PR TITLE
chore: update branch references from master to main in workflows and documentation

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -3,7 +3,7 @@ name: Flux Diff
 
 on:
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
     paths: ["kubernetes/**"]
 
 concurrency:

--- a/.github/workflows/flux-hr-sync.yaml
+++ b/.github/workflows/flux-hr-sync.yaml
@@ -12,7 +12,7 @@ on:
         description: Helm Repository Name
         required: true
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
     paths: ["kubernetes/**/helmrelease.yaml"]
 
 jobs:

--- a/.github/workflows/flux-image-test.yaml
+++ b/.github/workflows/flux-image-test.yaml
@@ -3,7 +3,7 @@ name: Flux Image Test
 
 on:
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
     paths: ["kubernetes/**"]
 
 concurrency:

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -4,7 +4,7 @@ name: Label Sync
 on:
   workflow_dispatch:
   push:
-    branches: ["master"]
+    branches: ["main"]
     paths: [".github/labels.yaml"]
   schedule:
     - cron: "0 0 * * *" # Every day at midnight

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,7 +4,7 @@ name: Labeler
 on:
   workflow_dispatch:
   pull_request_target:
-    branches: ["master"]
+    branches: ["main"]
 
 jobs:
   labeler:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -19,7 +19,7 @@ on:
   schedule:
     - cron: "0 * * * *" # Every hour
   push:
-    branches: ["master"]
+    branches: ["main"]
     paths:
       - .github/renovate.json5
       - .github/renovate/**.json5

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _... automated via [Flux](https://github.com/fluxcd/flux2), [Renovate](https://g
 [![Discord](https://img.shields.io/discord/673534664354430999?style=for-the-badge&label&logo=discord&logoColor=white&color=blue)](https://discord.gg/home-operations)&nbsp;&nbsp;
 [![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.hypyr.space%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)&nbsp;&nbsp;
 [![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.hypyr.space%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=%20)](https://kubernetes.io)&nbsp;&nbsp;
-[![Renovate](https://img.shields.io/github/actions/workflow/status/cpritchett/homelab-cluster/renovate.yaml?branch=master&label=&logo=renovatebot&style=for-the-badge&color=blue)](https://github.com/cpritchett/homelab-cluster/actions/workflows/renovate.yaml)
+[![Renovate](https://img.shields.io/github/actions/workflow/status/cpritchett/homelab-cluster/renovate.yaml?branch=main&label=&logo=renovatebot&style=for-the-badge&color=blue)](https://github.com/cpritchett/homelab-cluster/actions/workflows/renovate.yaml)
 
 </div>
 

--- a/kubernetes/flux/config/cluster.yaml
+++ b/kubernetes/flux/config/cluster.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 15m
   url: ssh://git@github.com/cpritchett/homelab-cluster
   ref:
-    branch: master
+    branch: main
   secretRef:
     name: github-deploy-key
   ignore: |


### PR DESCRIPTION
Change all references from 'master' to 'main' in workflows and documentation to align with the new branch naming convention.